### PR TITLE
Add OmicsUri region, account_id, and default file_name support

### DIFF
--- a/omics/common/omics_file_types.py
+++ b/omics/common/omics_file_types.py
@@ -61,6 +61,12 @@ OMICS_URI_TYPE_FILENAME_MAP = {
 }
 
 
+OMICS_URI_TYPE_DEFAULT_FILENAME_MAP = {
+    OmicsFileType.READSET: ReadSetFileName.SOURCE1,
+    OmicsFileType.REFERENCE: ReferenceFileName.SOURCE,
+}
+
+
 class ReadSetFileType(ExtendedEnum):
     """Available read set file types."""
 

--- a/tests/uriparse/__init__.py
+++ b/tests/uriparse/__init__.py
@@ -4,3 +4,9 @@ VALID_READSET_URI = (
 VALID_REFERENCE_URI = (
     "omics://123412341234.storage.us-east-1.amazonaws.com/5432154321/reference/5346184667/index"
 )
+VALID_READSET_DEFAULT_FILE_URI = (
+    "omics://123412341234.storage.us-west-2.amazonaws.com/5432154321/readSet/5346184667"
+)
+VALID_REFERENCE_DEFAULT_FILE_URI = (
+    "omics://123412341234.storage.us-west-2.amazonaws.com/5432154321/reference/5346184667"
+)

--- a/tests/uriparse/unit/test_uri_parse.py
+++ b/tests/uriparse/unit/test_uri_parse.py
@@ -2,6 +2,7 @@ import unittest
 
 from omics.uriparse.uri_parse import OmicsUri, OmicsUriParser
 from tests.uriparse import VALID_READSET_URI, VALID_REFERENCE_URI
+from tests.uriparse import VALID_READSET_DEFAULT_FILE_URI, VALID_REFERENCE_DEFAULT_FILE_URI
 
 
 class UriParserTest(unittest.TestCase):
@@ -13,46 +14,71 @@ class UriParserTest(unittest.TestCase):
         res = OmicsUriParser(VALID_READSET_URI).parse()
         assert res.resource_type == "READSET"
         assert res.file_name == "SOURCE2"
+        assert res.region == "us-east-1"
+        assert res.account_id == "123412341234"
+
+    def test_parser_valid_readset_default_file_uri(self):
+        res = OmicsUriParser(VALID_READSET_DEFAULT_FILE_URI).parse()
+        assert res.resource_type == "READSET"
+        assert res.file_name == "SOURCE1"
+        assert res.region == "us-west-2"
+        assert res.account_id == "123412341234"
 
     def test_parser_valid_reference_uri(self):
         res = OmicsUriParser(VALID_REFERENCE_URI).parse()
         assert res.resource_type == "REFERENCE"
         assert res.file_name == "INDEX"
+        assert res.region == "us-east-1"
+        assert res.account_id == "123412341234"
+
+    def test_parser_valid_reference_default_file_uri(self):
+        res = OmicsUriParser(VALID_REFERENCE_DEFAULT_FILE_URI).parse()
+        assert res.resource_type == "REFERENCE"
+        assert res.file_name == "SOURCE"
+        assert res.region == "us-west-2"
+        assert res.account_id == "123412341234"
 
     def test_invalid_uri_scheme(self):
         with self.assertRaises(ValueError):
             OmicsUri(
                 "http://123412341234.storage.us-east-1.amazonaws.com/5432154321/readSet/5346184667/source1"
-            ).parse()
+            )
 
     def test_invalid_uri_netlock(self):
         with self.assertRaises(ValueError):
             OmicsUri(
                 "omics://123412341234.something.us-east-1.amazonaws.com/5432154321/readSet/5346184667/source1"
-            ).parse()
+            )
+
+    def test_invalid_uri(self):
+        invalid_uri = "omics://123412341234.storage.us-east-1.amazonaws.com/5432154321/invalid/5346184667/source"
+        with self.assertRaises(ValueError):
+            OmicsUri(invalid_uri)
 
     # Readset tests
-    def test_readset_invalid_uri(self):
+    def test_readset_invalid_id(self):
+        invalid_uri = "omics://123412341234.storage.us-east-1.amazonaws.com/5432154321/readSet/"
         with self.assertRaises(ValueError):
-            OmicsUri("invalid").parse()
+            OmicsUri(invalid_uri)
 
     def test_readset_invalid_file(self):
         INVALID_READSET_URI = "omics://123412341234.storage.us-east-1.amazonaws.com/5432154321/readSet/5346184667/source"
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             OmicsUri(VALID_READSET_URI + "2")
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             OmicsUri(INVALID_READSET_URI)
 
     # Reference tests
-    def test_reference_invalid_uri(self):
+    def test_reference_invalid_id(self):
+        invalid_uri = "omics://123412341234.storage.us-east-1.amazonaws.com/5432154321/reference/"
         with self.assertRaises(ValueError):
-            OmicsUri("invalid").parse()
+            OmicsUri(invalid_uri)
 
     def test_reference_invalid_file(self):
         INVALID_REFERENCE_URI = "omics://123412341234.storage.us-east-1.amazonaws.com/5432154321/reference/5346184667/source2"
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             OmicsUri(VALID_REFERENCE_URI + "2")
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             OmicsUri(INVALID_REFERENCE_URI)
 
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Parse region and account ID segments of the URI and add corresponding attributes to OmicsUri
- Allow URIs with no file_name segment, adding in the default file, SOURCE1 for a ReadSet or SOURCE for a Reference
- Tighten URI parsing by using a regular expression
- Extend and add unit tests to bring URI parser coverage to 100%

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
