### PR TITLE
Properly set workflow type for rerun

### DIFF
--- a/omics/cli/rerun/__main__.py
+++ b/omics/cli/rerun/__main__.py
@@ -163,6 +163,10 @@ def get_run_resources(logs, run):
         rqst["nextToken"] = token
     return sorted(resources, key=lambda x: x.get("creationTime"))
 
+def get_workflow_type(run):
+    if not run.get("workflow", None) or len(run["workflow"].split(":")) < 5:
+        die(f"Failed to retrieve workflow type from run {run['arn']}")
+    return "READY2RUN" if not run["workflow"].split(":")[4] else "PRIVATE"
 
 def start_run_request(run, opts={}):
     """Build StartRun request"""
@@ -178,18 +182,17 @@ def start_run_request(run, opts={}):
     rqst = {}
     if opts.get("--workflow-id"):
         set_param(rqst, "workflowId", "--workflow-id")
-        if opts.get("--workflow-type"):
-            rqst["workflowType"] = opts["--workflow-type"]
     elif opts.get("--run-id"):
         set_param(rqst, "runId", "--run-id")
     elif run.get("run"):
         set_param(rqst, "runId", None, run["run"].split("/")[-1])
     else:
         set_param(rqst, "workflowId", None, run["workflow"].split("/")[-1])
-        if opts.get("--workflow-type"):
-            rqst["workflowType"] = opts["--workflow-type"]
-        elif not run["workflow"].split(":")[4]:
-            rqst["workflowType"] = "READY2RUN"
+
+    if opts.get("--workflow-type"):
+        set_param(rqst, "workflowType", "--workflow-type")
+    else:
+        rqst["workflowType"] = get_workflow_type(run)
 
     set_param(rqst, "roleArn", "--role-arn")
     set_param(rqst, "name", "--name")


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/amazon-omics-tools/issues/39

*Description of changes:*

We are not properly setting `workflowType` field when `--workflow-type` is not passed in by customer. This change ensures we default `workflowType` to the same as input run for the rerun tool

*Testing*

Tested the following commands, all worked as expected:
```
python3 -m omics.cli.rerun 2420306 
python3 -m omics.cli.rerun 2420306 --workflow-id 1830181
python3 -m omics.cli.rerun 2420306 --run-id 2420306 (this was triggering the same bug before as well)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
