### PR TITLE
Fixes dynamic storage issue for short runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ The CSV output by the command above includes the following columns:
 * __storageAverageGiB__ : Average gibibytes of storage used by the workflow run
 
 > [!WARNING]  
-> At this time AWS HealthOmics does not report the average or maximum storage used by runs that use "DYNAMIC" storage. Because of this limitation the `storageMaximumGiB` and `storageAverageGiB` are set to zero and will not be included in the estimate run cost.
+> At this time AWS HealthOmics does not report the average or maximum storage used by runs that use "DYNAMIC" storage that run for under two hours. Because of this limitation the `storageMaximumGiB` and `storageAverageGiB` are set to zero and will not be included in the estimate run cost.
 
 #### Output workflow run manifest in JSON format
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,9 @@ The CSV output by the command above includes the following columns:
 * __storageMaximumGiB__ : Maximum gibibytes of storage used during a single 1-minute interval
 * __storageAverageGiB__ : Average gibibytes of storage used by the workflow run
 
+> [!WARNING]  
+> At this time AWS HealthOmics does not report the average or maximum storage used by runs that use "DYNAMIC" storage. Because of this limitation the `storageMaximumGiB` and `storageAverageGiB` are set to zero and will not be included in the estimate run cost.
+
 #### Output workflow run manifest in JSON format
 
 ```bash

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -294,12 +294,10 @@ def add_metrics(res, resources, pricing):
     region = arn[3]
     res["type"] = rtype
 
-    # if a run has no metrics body then we can skip the rest
-    if rtype == "run" and not res["metrics"]:
-        return
-
     metrics = res.get("metrics", {})
-    res["metrics"] = metrics
+    # if a resource has no metrics body then we can skip the rest
+    if res.get("metrics") is None:
+        return
 
     if rtype == "run":
         add_run_util(res, resources[1:])

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -318,9 +318,9 @@ def add_metrics(res, resources, pricing):
     mem_max = metrics.get("memoryMaximumGiB")
     if mem_res and mem_max:
         metrics["memoryUtilizationRatio"] = float(mem_max) / float(mem_res)
-    store_res = metrics.get("storageReservedGiB")
-    store_max = metrics.get("storageMaximumGiB")
-    store_avg = metrics.get("storageAverageGiB")
+    store_res = metrics.get("storageReservedGiB", 0.0)
+    store_max = metrics.get("storageMaximumGiB", 0.0)
+    store_avg = metrics.get("storageAverageGiB", 0.0)
     if store_res and store_max:
         metrics["storageUtilizationRatio"] = float(store_max) / float(store_res)
 
@@ -337,7 +337,7 @@ def add_metrics(res, resources, pricing):
             price_resource_type = PRICE_RESOURCE_TYPE_DYNAMIC_RUN_STORAGE
             capacity = store_max
             charged = store_avg
-
+            
         # Get price for actually used storage (approx. for dynamic storage)
         gib_hrs = charged * running / SECS_PER_HOUR
         price = get_pricing(pricing, price_resource_type, region, gib_hrs)

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -337,7 +337,7 @@ def add_metrics(res, resources, pricing):
             price_resource_type = PRICE_RESOURCE_TYPE_DYNAMIC_RUN_STORAGE
             capacity = store_max
             charged = store_avg
-            
+
         # Get price for actually used storage (approx. for dynamic storage)
         gib_hrs = charged * running / SECS_PER_HOUR
         price = get_pricing(pricing, price_resource_type, region, gib_hrs)


### PR DESCRIPTION
*Issue #, if available:*
#37 
*Description of changes:*
HealthOmics doesn't currently report storage utilization metrics to the run manifest for DYNAMIC storage when the run length is under two hours. This works around this issue by defaulting these values to 0.0 preventing crashes until these values start being reported by the service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
