### PR TITLE
Cost estimates should use a min runtime of 1 minute

### DIFF
--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -359,9 +359,10 @@ def add_metrics(res, resources, pricing):
             metrics["minimumUSD"] = price
 
     elif "instanceType" in res:
+        runningForInstanceCost = max(60, running)
         itype = res["instanceType"]
         metrics["omicsInstanceTypeReserved"] = itype
-        price = get_pricing(pricing, itype, region, running / SECS_PER_HOUR)
+        price = get_pricing(pricing, itype, region, runningForInstanceCost / SECS_PER_HOUR)
         if price:
             metrics["estimatedUSD"] = price
         if cpus_max and mem_max and not gpus_res:
@@ -373,7 +374,7 @@ def add_metrics(res, resources, pricing):
             metrics["omicsInstanceTypeMinimum"] = itype
             metrics["recommendedCpus"] = cpus_res
             metrics["recommendedMemoryGiB"] = mem_res
-        price = get_pricing(pricing, itype, region, running / SECS_PER_HOUR)
+        price = get_pricing(pricing, itype, region, runningForInstanceCost / SECS_PER_HOUR)
         if price:
             metrics["minimumUSD"] = price
 

--- a/omics/cli/run_analyzer/timeline.py
+++ b/omics/cli/run_analyzer/timeline.py
@@ -54,9 +54,9 @@ def _get_task_timings_data(tasks, time_units="min"):
         task["running_right"] = (task["stopTime"] - tare).total_seconds() * time_scale_factor
         task["running_duration"] = task["running_right"] - task["running_left"]
 
-        task["queued_left"] = (task["creationTime"] - tare).total_seconds() * time_scale_factor
-        task["queued_right"] = task["running_left"]
-        task["queued_duration"] = task["queued_right"] - task["queued_left"]
+        task["starting_left"] = (task["creationTime"] - tare).total_seconds() * time_scale_factor
+        task["starting_right"] = task["running_left"]
+        task["starting_duration"] = task["starting_right"] - task["starting_left"]
 
         task["label"] = f"({task['arn']}) {task['name']}"
         task["text_x"] = (task["stopTime"] - tare).total_seconds() + 30 * time_scale_factor
@@ -81,7 +81,7 @@ def plot_timeline(tasks, title="", time_units="min", max_duration_hrs=5, show_pl
         ("gpus", "@gpus"),
         ("memory", "@memory GiB"),
         ("instanceType", "@instanceType"),
-        ("queued", f"@queued_duration {time_units}"),
+        ("starting", f"@starting_duration {time_units}"),
         ("duration", f"@running_duration {time_units}"),
         ("status", "@status"),
         ("est. cost USD", "@estimatedUSD"),
@@ -90,12 +90,12 @@ def plot_timeline(tasks, title="", time_units="min", max_duration_hrs=5, show_pl
     p_run = figure(width=960, height=800, sizing_mode="stretch_both", tooltips=tooltips)
     p_run.hbar(
         y="y",
-        left="queued_left",
-        right="queued_right",
+        left="starting_left",
+        right="starting_right",
         height=0.8,
         color="lightgrey",
         source=source,
-        legend_label="queued",
+        legend_label="starting",
     )
     p_run.hbar(
         y="y",

--- a/omics/cli/run_analyzer/timeline.py
+++ b/omics/cli/run_analyzer/timeline.py
@@ -84,7 +84,7 @@ def plot_timeline(tasks, title="", time_units="min", max_duration_hrs=5, show_pl
         ("starting", f"@starting_duration {time_units}"),
         ("duration", f"@running_duration {time_units}"),
         ("status", "@status"),
-        ("est. cost USD", "@estimatedUSD"),
+        ("est. cost USD", "@estimatedUSD{0.00000}"),
     ]
 
     p_run = figure(width=960, height=800, sizing_mode="stretch_both", tooltips=tooltips)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Cost estimates should use a min runtime of 1 minute 
- Dropped the exponential notation from the USD dollar notation and made it represented to 5 decimal place in timeline plot


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
