### PR TITLE
Add option to output a new config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,9 @@ For rows that are a _task_ type, the maximums, averages and reserved columns ref
 Based on the metrics observed and calculated for a run, the application will recommend the smallest instance type that could be used for each task in the run. The type is reported in the `omicsInstanceTypeMinimum` column. To obtain this type for a task you can set the task CPU and memory requested for the task to the values of `recommendedCpus` and  `recommendedMemoryGiB` in you workflow definition. Based on this change each task would be estimated to
 reduce the cost of the run by `estimatedUSD` minus `minimumUSD`. The total potential cost reduction for the entire run can be estimated by subtracting the `minimumUSD` value from the `estimatedUSD` value in the row where the `type` is "`run`".
 
+> [!WARNING]
+> Cost estimates are based on the AWS list price at the time the run analysis is performed. In the event prices have changed these may not reflect the price you were charged at the time of the run. Further, the run analyzer does not account for any discounts, credits or price agreements you may have. Price estimates for recommended instance sizes (`minimumUSD`) assume that the runtime of the task will remain the same on the recommended instance. Actual costs will be determined based on the actual runtime.
+
 #### Add headroom to recommendations
 
 Sometimes you will see variance in the amount of memory and CPU used in a run task, especially if you expect to run workflows with larger input files than were used in the analyzed run. For this reason you might want to allow add some headroom to the recommendations produced by the the run analyzer.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,17 @@ AWS HealthOmics Tools is available through pypi. To install, type:
 pip install amazon-omics-tools
 ```
 
-To install from source:
+### Install from source
+
+Installing from source requires that your machine has the following prerequisites installed: 
+- `python3.10` or above
+- `poetry` package manager
+- `make` build tool
 
 ```
 git clone https://github.com/awslabs/amazon-omics-tools.git
-pip install ./amazon-omics-tools
+cd ./amazon-omics-tools
+make install
 ```
 
 ## SDK Tools

--- a/README.md
+++ b/README.md
@@ -432,6 +432,15 @@ this returns something like:
 omics-run-analyzer: wrote run-1234567.json
 ```
 
+#### Output optimized configuration
+> [!WARNING]
+> Currently this feature only supports Nextflow workflows.
+
+The `--write-config` option will write a new configuration file with the `recommendedCpus` and `recommendedMemoryGiB` as the resource requirements. This will take the maximum values if the task is run multiple times with different inputs. 
+
+```bash
+python -m omics.cli.run_analyzer 123456 --write-config=optimized.config
+```
 ## Security
 
 See [CONTRIBUTING](https://github.com/awslabs/amazon-omics-tools/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -25,7 +25,7 @@ Options:
  -o, --out=<path>         Write output to file
  -P, --plot=<directory>   Plot a run timeline to a directory
  -H, --headroom=<float>   Adds a fractional buffer to the size of recommended memory and CPU. Values must be between 0.0 and 1.0.
- -c, --config=<path>      Output a config file with recommended resources
+ -c, --config=<path>      Output a config file with recommended resources (Nextflow only)
  -h, --help               Show help text
 
 Examples:
@@ -426,23 +426,9 @@ def create_config(engine, task_resources, filename):
                 out.write(task_string)
             
     elif engine == 'CWL':
-        with open(filename, "w") as out:
-            for task in task_resources:
-                task_string = textwrap.dedent(f"""
-                {task}:
-                    coresMin: {task_resources[task]['cpus']}
-                    ramMin: {task_resources[task]['mem']}
-                """)
-                out.write(task_string)
+        raise ValueError("--config does not currently support CWL workflows")
     elif engine == 'WDL':
-        with open(filename, "w") as out:
-            for task in task_resources:
-                task_string = textwrap.dedent(f"""
-                {task}:
-                    cpu: "{task_resources[task]['cpus']}"
-                    memory: "{task_resources[task]['mem']}"
-                """)
-                out.write(task_string)
+        raise ValueError("--config does not currently support WDL workflows")
     else:
         raise ValueError("Unknown workflow engine")
 
@@ -452,11 +438,9 @@ def get_base_task(engine, task):
         individual_task = task.split(" ")[0]
         return individual_task
     elif engine == 'CWL':
-        individual_task = task.split(" ")[0]
-        return individual_task
+        return task
     elif engine == 'WDL':
-        individual_task = task.split(" ")[0]
-        return individual_task
+        return task
     else:
         raise ValueError("Unknown workflow engine")
 

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -426,7 +426,14 @@ def create_config(engine, task_resources, filename):
                 out.write(task_string)
             
     elif engine == 'CWL':
-        pass
+        with open(filename, "w") as out:
+            for task in task_resources:
+                task_string = textwrap.dedent(f"""
+                {task}:
+                    coresMin: {task_resources[task]['cpus']}
+                    ramMin: {task_resources[task]['mem']}
+                """)
+                out.write(task_string)
     elif engine == 'WDL':
         pass
     else:
@@ -560,6 +567,11 @@ if __name__ == "__main__":
                         config[task_name] ={
                             'cpus': metrics['recommendedCpus'],
                             'mem': metrics['recommendedMemoryGiB']
+                        }
+                    else:
+                        config[task_name] ={
+                            'cpus': max(metrics['recommendedCpus'], config[task_name]['cpus']),
+                            'mem': max(metrics['recommendedMemoryGiB'], config[task_name]['mem'])
                         }
                 row = [tocsv(metrics.get(h, res.get(h))) for h in hdrs]
                 writer.writerow(row)

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -445,7 +445,20 @@ def create_config(engine, task_resources, filename):
                 out.write(task_string)
     else:
         raise ValueError("Unknown workflow engine")
-    
+
+def get_base_task(engine, task):
+    # Returns the base task name
+    if engine == 'NEXTFLOW':
+        individual_task = task.split(" ")[0]
+        return individual_task
+    elif engine == 'CWL':
+        individual_task = task.split(" ")[0]
+        return individual_task
+    elif engine == 'WDL':
+        individual_task = task.split(" ")[0]
+        return individual_task
+    else:
+        raise ValueError("Unknown workflow engine")
 
 
 if __name__ == "__main__":
@@ -569,7 +582,7 @@ if __name__ == "__main__":
                     wfid = res['workflow'].split('/')[-1]
                     engine = omics.get_workflow(id=wfid)['engine']
                 if res['type'] == 'task':
-                    task_name = res['name'].split(" ")[0]
+                    task_name = get_base_task(engine, res['name'])
                     if task_name not in config.keys():
                         config[task_name] ={
                             'cpus': metrics['recommendedCpus'],

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -435,7 +435,14 @@ def create_config(engine, task_resources, filename):
                 """)
                 out.write(task_string)
     elif engine == 'WDL':
-        pass
+        with open(filename, "w") as out:
+            for task in task_resources:
+                task_string = textwrap.dedent(f"""
+                {task}:
+                    cpu: "{task_resources[task]['cpus']}"
+                    memory: "{task_resources[task]['mem']}"
+                """)
+                out.write(task_string)
     else:
         raise ValueError("Unknown workflow engine")
     

--- a/omics/cli/run_analyzer/timeline.py
+++ b/omics/cli/run_analyzer/timeline.py
@@ -89,6 +89,7 @@ def plot_timeline(tasks, title="", time_units="min", max_duration_hrs=5, show_pl
 
     p_run = figure(width=960, height=800, sizing_mode="stretch_both", tooltips=tooltips)
     p_run.hbar(
+        # start time bar
         y="y",
         left="starting_left",
         right="starting_right",
@@ -98,6 +99,7 @@ def plot_timeline(tasks, title="", time_units="min", max_duration_hrs=5, show_pl
         legend_label="starting",
     )
     p_run.hbar(
+        # running time bar
         y="y",
         left="running_left",
         right="running_right",
@@ -106,9 +108,12 @@ def plot_timeline(tasks, title="", time_units="min", max_duration_hrs=5, show_pl
         source=source,
         legend_label="running",
     )
-    if len(data) < 50:
+    if len(data) < 101:
         p_run.text(
-            x="text_x",
+            # task name label
+            color="black",
+            x="running_right",
+            x_offset=10,
             y="y",
             text="name",
             alpha=0.4,

--- a/omics/cli/run_analyzer/writeconfig.py
+++ b/omics/cli/run_analyzer/writeconfig.py
@@ -1,0 +1,32 @@
+import textwrap
+
+def create_config(engine, task_resources, filename):
+    if engine == 'NEXTFLOW':
+        with open(filename, 'w') as out:
+            for task in task_resources:
+                task_string = textwrap.dedent(f"""
+                withName: {task} {{
+                    cpu = {task_resources[task]['cpus']}
+                    memory = {task_resources[task]['mem']}
+                }}
+                """)
+                out.write(task_string)
+            
+    elif engine == 'CWL':
+        raise ValueError("--write-config does not currently support CWL workflows")
+    elif engine == 'WDL':
+        raise ValueError("--write-config does not currently support WDL workflows")
+    else:
+        raise ValueError("Unknown workflow engine")
+
+def get_base_task(engine, task):
+    # Returns the base task name
+    if engine == 'NEXTFLOW':
+        individual_task = task.split(" ")[0]
+        return individual_task
+    elif engine == 'CWL':
+        return task
+    elif engine == 'WDL':
+        return task
+    else:
+        raise ValueError("Unknown workflow engine")

--- a/tests/run_analyzer/unit/test_writeconfig.py
+++ b/tests/run_analyzer/unit/test_writeconfig.py
@@ -1,0 +1,14 @@
+import unittest
+from omics.cli.run_analyzer import writeconfig
+
+class TestGetBaseTask(unittest.TestCase):
+    def test_get_base_task_nextflow(self):
+        result = writeconfig.get_base_task('NEXTFLOW', 'task1 (sample1)')
+        self.assertEqual(result, 'task1')
+
+    def test_get_base_task_cwl(self):
+        result = writeconfig.get_base_task('CWL', 'task1 (sample1)')
+        self.assertRaises(ValueError)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**DRAFT**: Need to add CWL and WDL formatting still. 
Adds `--config=<path>` which if specified will create a configuration file formatted correctly for the workflow's engine. The below for example would be correctly formatted for NF. This would enable users to directly utilize recommended settings from the runanalyzer. 

```
withName: TEST {
    cpu = 2
    memory = 4
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
