### PR TITLE
Fix for dropped events

### DIFF
--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -220,15 +220,13 @@ def get_run_resources(logs, run):
         "logGroupName": OMICS_LOG_GROUP,
         "logStreamName": run["logStreamName"],
         "startFromHead": True,
+        "endTime":  run["lastEventTimestamp"] + 1,
     }
     resources = []
     done = False
     while not done:
-        resp = logs.get_log_events(**rqst, limit=1024)
-        events = resp.get("events", [])
-        if not events:
-            done = True
-        for evt in resp.get("events"):
+        resp = logs.get_log_events(**rqst)
+        for evt in resp.get("events", []):
             resources.append(json.loads(evt["message"]))
         token = resp.get("nextForwardToken")
         if not token or token == rqst.get("nextToken"):

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -220,7 +220,7 @@ def get_run_resources(logs, run):
         "logGroupName": OMICS_LOG_GROUP,
         "logStreamName": run["logStreamName"],
         "startFromHead": True,
-        "endTime":  run["lastEventTimestamp"] + 1,
+        "endTime": run["lastEventTimestamp"] + 1,
     }
     resources = []
     done = False

--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -167,6 +167,7 @@ def stream_to_run(strm):
 def get_streams(logs, rqst, start_time=None):
     """Get matching CloudWatch Log streams"""
     streams = []
+    # using boto3 get the log stream descriptions for the request, paginating the responses
     for page in logs.get_paginator("describe_log_streams").paginate(**rqst):
         done = False
         for strm in page["logStreams"]:
@@ -223,14 +224,12 @@ def get_run_resources(logs, run):
     resources = []
     done = False
     while not done:
-        resp = logs.get_log_events(**rqst)
-        for evt in resp.get("events", []):
-            try:
-                resources.append(json.loads(evt["message"]))
-            except Exception:
-                pass
-            if evt["timestamp"] >= run["lastEventTimestamp"]:
-                done = True
+        resp = logs.get_log_events(**rqst, limit=1024)
+        events = resp.get("events", [])
+        if not events:
+            done = True
+        for evt in resp.get("events"):
+            resources.append(json.loads(evt["message"]))
         token = resp.get("nextForwardToken")
         if not token or token == rqst.get("nextToken"):
             done = True


### PR DESCRIPTION
*Description of changes:*
The previous pagination of `get_log_events` could drop events when there were large numbers of events written with the same `timestamp` as the runs `lastEventTimeStamp`. Because of the large page sizes of CloudWatch you only see this in very large runs.

This fix adds an explicit `endTime` to the request which is the last event timestamp of the run. This constrains the logstream to have a finish so that when done it will return a `nextForwardToken` equal to the value of the token passed in the request. Without an explicit `endTime` the `nextForwardToken` is never the same and you are essentially tailing the log forever.

The fix simplifies the logic and also removes a dangerous place where exceptions can be swallowed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
